### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "f0c99c07667dfb58bac4cd9156e3d1ead9f3c78223a282301bc51f49b4efcf2d"
 
 [[package]]
 name = "shogi_legality_lite"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "shogi_core",
  "shogi_usi_parser",

--- a/shogi_legality_lite/Cargo.toml
+++ b/shogi_legality_lite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shogi_legality_lite"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Rust shogi crates developers"]
 edition = "2021"
 rust-version = "1.60"


### PR DESCRIPTION
Milestone: https://github.com/rust-shogi-crates/shogi_legality_lite/milestone/1?closed=1

Changes made in 0.1.0 -> 0.1.1:
- Bugfix in legality checking (https://github.com/rust-shogi-crates/shogi_legality_lite/pull/2)
- Add functions that enumerate checks (https://github.com/rust-shogi-crates/shogi_legality_lite/pull/2)
- Add ordering heuristics to mate_solver (https://github.com/rust-shogi-crates/shogi_legality_lite/pull/3)
- Export all methods of LiteLegalityChecker as normal functions (https://github.com/rust-shogi-crates/shogi_legality_lite/pull/5)
