### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "3d0a7de4ff7c66bf0b6346bda1d530c94a496f8aa3317938923886c58191aa14"
 
 [[package]]
 name = "shogi_legality_lite"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "shogi_core",
  "shogi_usi_parser",

--- a/shogi_legality_lite/Cargo.toml
+++ b/shogi_legality_lite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shogi_legality_lite"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Rust shogi crates developers"]
 edition = "2021"
 rust-version = "1.60"


### PR DESCRIPTION
Milestone: https://github.com/rust-shogi-crates/shogi_legality_lite/milestone/2?closed=1

Changes in 0.1.1...0.1.2:
- https://github.com/rust-shogi-crates/shogi_legality_lite/pull/7 (Export `prelegality`)
